### PR TITLE
[BUG] Change prometheus user shell path in /etc/passwd

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.yml linguist-detectable=true
+*.yaml linguist-detectable=true
+*.html linguist-detectable=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/prometheus_alertmanager_role/tree/develop)
 
+### Added
+- [#27](https://github.com/idealista/prometheus_alertmanager_role/issues/27) *[BUG] Change prometheus user shell path in /etc/passwd* @marcelogalmor
+
 ## [2.1.0](https://github.com/idealista/prometheus_alertmanager_role/tree/2.1.0) (2020-01-22)
 [Full Changelog](https://github.com/idealista/prometheus_alertmanager_role/compare/2.0.2...2.1.0)
 ### Changed

--- a/Pipfile
+++ b/Pipfile
@@ -6,8 +6,8 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-ansible = "==2.8.6"
-molecule = "==2.22"
+ansible = "==2.9.9"
+molecule = "==3.0.4"
 docker = "==4.1.0"
 
 [requires]

--- a/Pipfile
+++ b/Pipfile
@@ -6,8 +6,8 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-ansible = "==2.9.9"
-molecule = "==3.0.4"
+ansible = "==2.9.21"
+molecule = "==3.0.8"
 docker = "==4.1.0"
 
 [requires]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ These instructions will get you a copy of the role for your ansible playbook. On
 
 ### Prerequisities
 
-Ansible 2.9.9 version installed.
+Ansible 2.9.x.x version installed.
 Inventory destination should be a Debian environment.
 
 For testing purposes, [Molecule](https://molecule.readthedocs.io/) with [Docker](https://www.docker.com/) as driver. Pipenv 2018.11.26 and Python 3 recommended.
@@ -73,8 +73,8 @@ molecule test
 
 ## Built With
 
-![Ansible](https://img.shields.io/badge/ansible-2.9.9-green.svg)
-![Molecule](https://img.shields.io/badge/molecule-3.0.4-green.svg)
+![Ansible](https://img.shields.io/badge/ansible-2.9.21-green.svg)
+![Molecule](https://img.shields.io/badge/molecule-3.0.8-green.svg)
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ These instructions will get you a copy of the role for your ansible playbook. On
 
 ### Prerequisities
 
-Ansible 2.8.x.x version installed.
+Ansible 2.9.9 version installed.
 Inventory destination should be a Debian environment.
 
 For testing purposes, [Molecule](https://molecule.readthedocs.io/) with [Docker](https://www.docker.com/) as driver. Pipenv 2018.11.26 and Python 3 recommended.
@@ -73,8 +73,8 @@ molecule test
 
 ## Built With
 
-![Ansible](https://img.shields.io/badge/ansible-2.8.6.0-green.svg)
-![Molecule](https://img.shields.io/badge/molecule-2.22.0-green.svg)
+![Ansible](https://img.shields.io/badge/ansible-2.9.9-green.svg)
+![Molecule](https://img.shields.io/badge/molecule-3.0.4-green.svg)
 
 ## Versioning
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ alertmanager_force_reinstall: false
 # Owner
 alertmanager_user: prometheus
 alertmanager_group: prometheus
+alertmanager_user_shell: /usr/sbin/nologin
 
 # start on boot
 alertmanager_service_enabled: True

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -11,7 +11,7 @@
     name: "{{ alertmanager_user }}"
     group: "{{ alertmanager_group }}"
     system: yes
-    shell: /sbin/nologin
+    shell: /usr/sbin/nologin
     createhome: no
 
 - name: ALERTMANAGER | Ensure skeleton paths

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -11,7 +11,7 @@
     name: "{{ alertmanager_user }}"
     group: "{{ alertmanager_group }}"
     system: yes
-    shell: /usr/sbin/nologin
+    shell: "{{ alertmanager_user_shell }}"
     createhome: no
 
 - name: ALERTMANAGER | Ensure skeleton paths


### PR DESCRIPTION
<!--
PREREQUISITES

Have you read Idealista's Code of Conduct? By filling an Issue, you are expected to comply with it,
 including treating everyone with respect: https://github.com/idealista/idealista/blob/master/CODE_OF_CONDUCT.md

Check that your issue isn't already filled: https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Aidealista

Check that there is not already provided the described functionality
-->

### Description

To solve the idempotency of abv-monitor-playbook it is necessary to match the path of the prometheus user shell as the rest of the roles on which it depends:

* Change /sbin/nologin to /usr/sbin/nologin.

Some versions in the Pipfile could be updated (be aware to not break CI)

### Why is this needed?

So the role is updated along all the roles

### Additional Information

N/A
