### PR TITLE
#33 remove jinja extension from config parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/prometheus_alertmanager_role/tree/develop)
+- *[#33](https://github.com/idealista/prometheus_alertmanager_role/issues/33) Remove jinja extension from the config parts* @blalop
 
 ## [3.0.0](https://github.com/idealista/prometheus_alertmanager_role/tree/3.0.0) (2022-07-21)
 ### Added

--- a/molecule/default/tests/test_alertmanager.yml
+++ b/molecule/default/tests/test_alertmanager.yml
@@ -34,6 +34,12 @@ file:
     group: {{ alertmanager_group }}
     exists: true
     filetype: directory
+  {{ alertmanager_conf_path }}/parts/2_routes_alertmanager:
+    exists: true
+  {{ alertmanager_conf_path }}/parts/3_inhibit_rules_alertmanager:
+    exists: true
+  {{ alertmanager_conf_path }}/parts/4_receivers_alertmanager:
+    exists: true
   /lib/systemd/system/alertmanager.service:
     exists: true
 

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -11,7 +11,7 @@
 - name: ALERTMANAGER | Copy server config
   template:
     src: "{{ item }}"
-    dest: "{{ alertmanager_conf_path }}/parts/{{ item | basename }}"
+    dest: "{{ alertmanager_conf_path }}/parts/{{ item | basename | splitext | first }}"
     owner: "{{ alertmanager_user }}"
     group: "{{ alertmanager_group }}"
     mode: 0640


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change
Remove .j2 extension from the config parts files.


### Benefits

Keep it clean.

### Possible Drawbacks

N/A

### Applicable Issues

#33 
